### PR TITLE
Support for type 'any'

### DIFF
--- a/examples/unified-api.yaml
+++ b/examples/unified-api.yaml
@@ -166,6 +166,20 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/StatusResponse'}
 
+  /v1/playground:
+    get:
+      tags:
+        - Playground Service
+      summary: Used to test st-open-api
+      operationId: playAround
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PlaygroundResponse'}
+
+
 components:
   schemas:
     
@@ -307,6 +321,30 @@ components:
           $ref: '#/components/schemas/StatusResponse'
         result:
           $ref: '#/components/schemas/OffsetInfoResponse'
+
+    PlaygroundResponse:
+      title: PlaygroundResponse
+      type: object
+      properties:
+        anyType:
+          $ref: '#/components/schemas/AnyType'
+        numberType:
+          $ref: '#/components/schemas/NumberType'
+        integerType:
+          $ref: '#/components/schemas/IntegerType'
+        booleanType:
+          $ref: '#/components/schemas/BooleanType'
+        primitiveAnyType: {}
+
+    AnyType: {}
+    StringType:
+      type: string
+    NumberType:
+      type: number
+    IntegerType:
+      type: integer
+    BooleanType:
+      type: boolean
 
   securitySchemes:
     bearerAuth:

--- a/src/classes/primitive-type-property.ts
+++ b/src/classes/primitive-type-property.ts
@@ -1,0 +1,43 @@
+import {IPropertyClass, IRenderResult} from "../interface/i-property-class";
+import {renderMustache} from "../function/render-mustache";
+import {formatText} from "../function/formatText";
+
+
+export class PrimitiveTypeProperty implements IPropertyClass {
+
+    typeName: string;
+    fileName: string;
+    primitiveType: string;
+
+    constructor(originalName: string) {
+        this.convertName(originalName);
+    }
+
+    convertName(originalName: string) {
+        this.typeName = formatText(originalName, 'ANY', 'PascalCase');
+        this.fileName = formatText(originalName, 'ANY', 'KebabCase');
+    }
+
+    setPrimitiveType(primitiveType: string) {
+        this.primitiveType = primitiveType
+        
+    }
+
+    render(): IRenderResult {
+        const viewData: IMustachePrimitiveType = {
+            typeName: this.typeName,
+            primitiveType: this.primitiveType
+        }
+        return {
+            classEnumName: this.typeName,
+            fileName: this.fileName,
+            render: renderMustache('primitive-type.mustache', viewData)
+        }
+    }
+}
+
+interface IMustachePrimitiveType {
+    typeName: string;
+    primitiveType: string;
+}
+

--- a/src/function/get-property.ts
+++ b/src/function/get-property.ts
@@ -10,8 +10,9 @@ import {mkdir} from "../classes/folder-manager";
 import {configuration} from "./config";
 import {InterfaceArrayProperty} from "../classes/interface-array-property";
 import {formatText} from "./formatText";
+import { PrimitiveTypeProperty } from "../classes/primitive-type-property";
 
-export const getInterfaceOrEnumFromSchema = (className: string, originalName: string, schema: ISchema, path: string): InterfaceProperty | EnumProperty | InterfaceArrayProperty => {
+export const getInterfaceOrEnumFromSchema = (className: string, originalName: string, schema: ISchema, path: string): InterfaceProperty | EnumProperty | InterfaceArrayProperty | PrimitiveTypeProperty => {
     const isDebug = configuration.isDebug();
     if (isDebug) {
         console.log(`Get enum or interface ${className}`)
@@ -77,6 +78,10 @@ export const getInterfaceOrEnumFromSchema = (className: string, originalName: st
         const enumClass = new EnumProperty(className);
         enumClass.setValues(schema.enum);
         return enumClass;
+    } else if (isPrimitive(schema.type)) {
+        const primitiveTypeClass = new PrimitiveTypeProperty(className);
+        primitiveTypeClass.setPrimitiveType(mapType(schema.type))
+        return primitiveTypeClass;
     } else {
         console.log(className, originalName, 'no mapping for schema found')
     }
@@ -193,20 +198,28 @@ const getReference = (schema: ISchema) => {
     }
 }
 
-const mapType = (type: string) => {
-    return type === 'integer' ? 'number' : type;
+const mapType = (type: string | undefined) => {
+    switch (type) {
+        case "integer":
+          return "number";
+        case undefined:
+          return "any";
+        default:
+          return type;
+      };
 }
 
 const getNestedPath = (path: string, type: string) => {
     return mkdir(join(path, type));
 }
 
-const isPrimitive = (type: string) => {
+const isPrimitive = (type: string | undefined) => {
     switch (type) {
         case "boolean":
         case "integer":
         case "number":
-        case  "string":
+        case "string":
+        case undefined:
             return true;
     }
     return false

--- a/src/interface/open-api-mine/i-schema.ts
+++ b/src/interface/open-api-mine/i-schema.ts
@@ -1,7 +1,7 @@
 import {IType} from "./i-type";
 
 export interface ISchema {
-    type: IType | 'object' | 'array';
+    type?: IType | 'object' | 'array';
     items?: ISchemaItem;
     required?: Array<string>;
     properties?: { [name: string]: ISchema };

--- a/template/mustache/ts/primitive-type.mustache
+++ b/template/mustache/ts/primitive-type.mustache
@@ -1,0 +1,4 @@
+/**
+ * This file was generated
+ */
+export type {{typeName}} = {{primitiveType}}


### PR DESCRIPTION
* Adds support for type 'any' as its own schema
```
components:
  schemas:
    AnyType: {}
```

results in
```
export type AnyType: any
```

* Adds support for type 'any' as primitive property type, following the OpenAPI 3.x.x specification that a schema or property without type declaration is allowed and interpreted as 'any'.
```
components:
  schemas:
    Response:
      type: object
      properties:
        anythingIsAllowed: {}
```

results in
```
export interface Response {
  anythingIsAllowed: any
}
```

* Adds support for other primitive types as Schemas, because why not:
```
components:
  schemas:
    StringType:
      type: string
    NumberType:
      type: number
```
results in
```
export type StringType: string
```
and
```
export type NumberType: number
```