### PR TITLE
support kebabcase request headers

### DIFF
--- a/examples/unified-api.yaml
+++ b/examples/unified-api.yaml
@@ -43,6 +43,13 @@ paths:
             schema:
               $ref: '#/components/schemas/OffsetRequest'
         required: true
+      parameters:
+        - name: X-Sdk-Version
+          in: header
+          description: SDK version header
+          schema:
+            type: string
+          required: false
       responses:
         200:
           description: OK; Offset has been scheduled correctly
@@ -172,6 +179,48 @@ paths:
         - Playground Service
       summary: Used to test st-open-api
       operationId: playAround
+      parameters:
+        - name: X-Sdk-Version
+          in: header
+          description: SDK version header
+          schema:
+            type: string
+          required: true
+        - name: my-optional-header
+          in: header
+          description: test
+          schema:
+            type: string
+          required: false
+        - name: headerInCamelCase
+          in: header
+          description: test
+          schema:
+            type: string
+          required: false
+        - name: header_in_snake_case
+          in: header
+          description: test
+          schema:
+            type: string
+          required: true
+        - name: queryParameter
+          in: query
+          description: test
+          schema:
+            type: string
+        - name: pathParameter
+          in: path
+          description: test
+          schema:
+            type: string
+          required: true
+        - name: cookieParameter
+          in: cookie
+          description: test
+          schema:
+            type: string
+          required: true
       responses:
         200:
           description: OK

--- a/src/classes/object-property.ts
+++ b/src/classes/object-property.ts
@@ -4,6 +4,7 @@ import {UniqueArray} from "./unique-array";
 import {splitByLineBreak} from "../function/split-by-line-break";
 import {FolderManager} from "./folder-manager";
 import {formatText} from "../function/formatText";
+import { IHeaderParameter } from "../interface/i-header-parameter";
 
 export const HTTP_FUNCTION_REF = (folder: FolderManager) => {
     return {
@@ -109,7 +110,13 @@ export class ObjectProperty implements IPropertyClass {
             queryParameterClassName: fun.queryParameters?.className,
 
             isHeaderParameters: !!fun.headerParameters,
-            headerParameters: fun.headerParameters?.params,
+            headerParameters: fun.headerParameters && Object.values(fun.headerParameters.params).map(param => {
+                return {
+                    name: param.name,
+                    nameOriginal: param.nameOriginal,
+                    required: param.required,
+                }
+            }),
             headerParameterClassName: fun.headerParameters?.className,
 
             isRequestBody: !!fun.requestBodyClass,
@@ -220,7 +227,7 @@ interface IMustacheFunction {
 
     isHeaderParameters: boolean;
     headerParameterClassName?: string;
-    headerParameters?: Array<string>;
+    headerParameters?: Array<{ name: string, nameOriginal: string, required: boolean }>;
 
     isRequestBody: boolean;
     requestBodyClass?: string;
@@ -243,7 +250,7 @@ export interface IFunction extends IFunctionResponse, IFunctionRequestBody {
     };
     headerParameters?: {
         className: string;
-        params: Array<string>
+        params: { [parameterName: string]: IHeaderParameter }
     };
     queryParameters?: {
         className: string;

--- a/src/function/get-service-http-function.ts
+++ b/src/function/get-service-http-function.ts
@@ -21,12 +21,20 @@ import {configuration} from "./config";
 import {formatText} from "./formatText";
 import {IParameter} from "../interface/open-api-mine/i-parameter";
 import {IRefResult} from "../classes/ref";
+import { IHeaderParameter } from "../interface/i-header-parameter";
 
-const createParameter = (
-    type: 'query' | 'header' | 'path' | 'cookie',
-    functionName: string,
-    parameters: { [parameterName: string]: IParameter }
-): IRefResult => {
+type CreateParameterArguments = 
+    {
+        type: 'query' | 'path' | 'cookie',
+        functionName: string,
+        parameters: { [parameterName: string]: IParameter }
+    } | {
+        type: 'header',
+        functionName: string,
+        parameters: { [parameterName: string]: IHeaderParameter }
+    }
+
+const createParameter = ({type, functionName, parameters}: CreateParameterArguments): IRefResult => {
     const parameterClassName = `I${functionName.substring(0, 1).toUpperCase()}${functionName.substring(1)}${type.substring(0, 1).toUpperCase()}${type.substring(1)}Parameter`;
 
     const reference = configuration.getReference();
@@ -93,19 +101,19 @@ export const getServiceHttpFunction = (objProperty: ObjectProperty, httpMethod: 
         operationFunction.imports.push(response.import);
 
         if (Object.keys(sortedParameter.query).length > 0) {
-            const {className, import: importString} = createParameter('query', functionName, sortedParameter.query)
+            const {className, import: importString} = createParameter({type: 'query', functionName, parameters: sortedParameter.query})
             operationFunction.queryParameters = {className, params: Object.keys(sortedParameter.query)};
             operationFunction.imports.push(importString);
         }
 
         if (Object.keys(sortedParameter.header).length > 0) {
-            const {className, import: importString} = createParameter('header', functionName, sortedParameter.header)
-            operationFunction.headerParameters = {className, params: Object.keys(sortedParameter.header)};
+            const {className, import: importString} = createParameter({type: 'header', functionName, parameters: sortedParameter.header})
+            operationFunction.headerParameters = {className, params: sortedParameter.header};
             operationFunction.imports.push(importString);
         }
 
         if (Object.keys(sortedParameter.path).length > 0) {
-            const {className, import: importString} = createParameter('path', functionName, sortedParameter.path)
+            const {className, import: importString} = createParameter({type: 'path', functionName, parameters: sortedParameter.path})
             operationFunction.pathParameters = {className, params: Object.keys(sortedParameter.path)};
             operationFunction.imports.push(importString);
         }

--- a/src/function/get-sorted-parameter.ts
+++ b/src/function/get-sorted-parameter.ts
@@ -1,5 +1,7 @@
 import {IParameter} from "../interface/open-api-mine/i-parameter";
 import {ISortedParameter} from "../interface/i-sorted-parameter";
+import { formatText } from "./formatText";
+import { IHeaderParameter } from "../interface/i-header-parameter";
 
 export const getSortedParameter = (path: string, parameters: Array<IParameter> = []): ISortedParameter => {
 
@@ -14,11 +16,23 @@ export const getSortedParameter = (path: string, parameters: Array<IParameter> =
         const typedParam = parameter as IParameter;
         const type = typedParam.in;
 
-        // no apply of 'authorization' header in each API endpoint;
-        // this shall be done in an interceptor
-        if (type === 'header' && typedParam.name === 'authorization') continue;
-        
-        result[type][typedParam.name] = typedParam;
+        if (type === 'header') {
+            // no apply of 'authorization' header in each API endpoint;
+            // this shall be done in an interceptor
+            if (typedParam.name === 'authorization') {
+                continue;
+            }
+            const typedParamFormatted: IHeaderParameter = {
+                ...typedParam, 
+                name: formatText(typedParam.name, 'ANY', 'CamelCase'),      // HTTP headers often use Upper-Kebab-Case
+                nameOriginal: typedParam.name
+            };
+            result[type][typedParam.name] = typedParamFormatted;
+        }
+
+        else {
+            result[type][typedParam.name] = typedParam;
+        }
     }
 
     return result

--- a/src/interface/i-header-parameter.ts
+++ b/src/interface/i-header-parameter.ts
@@ -1,0 +1,5 @@
+import { IParameter } from "./open-api-mine/i-parameter";
+
+export interface IHeaderParameter extends IParameter { 
+    nameOriginal: string 
+} 

--- a/src/interface/i-sorted-parameter.ts
+++ b/src/interface/i-sorted-parameter.ts
@@ -1,8 +1,9 @@
+import { IHeaderParameter } from "./i-header-parameter";
 import {IParameter} from "./open-api-mine/i-parameter";
 
 export interface ISortedParameter {
     'query': { [parameterName: string]: IParameter }
     'path': { [parameterName: string]: IParameter }
     'cookie': { [parameterName: string]: IParameter }
-    'header': { [parameterName: string]: IParameter }
+    'header': { [parameterName: string]: IHeaderParameter }
 }

--- a/template/mustache/ts/function-class.mustache
+++ b/template/mustache/ts/function-class.mustache
@@ -47,7 +47,12 @@
 {{/isRequestBodyJson}}
 {{#isHeaderParameters}}
 {{#headerParameters}}
-                '{{.}}': headerParameter.{{.}},
+    {{#required}}
+                '{{nameOriginal}}': headerParameter.{{name}},
+    {{/required}}
+    {{^required}}
+                ...(headerParameter.{{name}} && {['{{nameOriginal}}']: headerParameter.{{name}}}),
+    {{/required}}
 {{/headerParameters}}
 {{/isHeaderParameters}}
             },

--- a/template/mustache/ts/function-class.mustache
+++ b/template/mustache/ts/function-class.mustache
@@ -51,7 +51,7 @@
                 '{{nameOriginal}}': headerParameter.{{name}},
     {{/required}}
     {{^required}}
-                ...(headerParameter.{{name}} && {['{{nameOriginal}}']: headerParameter.{{name}}}),
+                ...(headerParameter.{{name}} && {'{{nameOriginal}}': headerParameter.{{name}}}),
     {{/required}}
 {{/headerParameters}}
 {{/isHeaderParameters}}


### PR DESCRIPTION
The previous version was not able to generate types for headers in kebab-case.
Example:
```
  /v1/playground:
    get:
      parameters:
        - name: X-Sdk-Version
          in: header
          schema:
            type: string
          required: true
```
would result in the following service definition:

```
playAround = async (
  headerParameter: IPlayAroundHeaderParameter, 
  ...
): Promise<IPlaygroundResponse> => {
    
        const response = await http({
                method: 'GET',
                url: `${openApi.endpointUrl}/v1/playground`,
                header: {
                    'X-Sdk-Version': headerParameter.X-Sdk-Version,
```
The last line leads to a syntax error, due to the dashes in the parameter name.

Similar for the type generation of `IPlayAroundHeaderParameter`. The parameter name with dashes is not valid javascript code:
```
export interface IPlayAroundHeaderParameter {
    X-Sdk-Version: string;
}
```

An easy fix would be to add ' ' around the parameter names. However, the parameter names should follow the general code style and be in camelCase. It's also not a solution to convert the header parameter to camelCase and forget about its original name, because the original name is required in the header definition. Hence, this PR generates the code like this:

 ```
playAround = async (
  headerParameter: IPlayAroundHeaderParameter, 
  ...
): Promise<IPlaygroundResponse> => {
    
        const response = await http({
                method: 'GET',
                url: `${openApi.endpointUrl}/v1/playground`,
                header: {
                    'X-Sdk-Version': headerParameter.xSdkVersion,
```

In the last line, we keep the original name of the parameter for the HTTP request, but the attribute of headerParameter is in camelCase.
Similar in the interface:
```
export interface IPlayAroundHeaderParameter {
    xSdkVersion: string;
}
```

The changes are backwards-compatible. Parameters that were in camelCase before are still handled the same.